### PR TITLE
rt5665 and a few others are causing kernel panics, so let's just opti…

### DIFF
--- a/sound/soc/codecs/Makefile
+++ b/sound/soc/codecs/Makefile
@@ -489,3 +489,7 @@ obj-$(CONFIG_SND_SOC_TAS2562)	+= tas2562/
 
 # DBMDx
 obj-$(CONFIG_SND_SOC_DBMDX)	+= dbmdx/
+
+CFLAGS_rt5665.o := $(DISABLE_LTO)
+CFLAGS_snd-soc-rt5665.o := $(DISABLE_LTO)
+KBUILD_CFLAGS   += -Os


### PR DESCRIPTION
…mize all of them for size only and disable LTO for it.

Fixes kernel panics for the users with these modules