### PR TITLE
Fix: fs/ecryptfs/keystore.c

### DIFF
--- a/fs/ecryptfs/keystore.c
+++ b/fs/ecryptfs/keystore.c
@@ -2537,7 +2537,7 @@ write_tag_3_packet(char *dest, size_t *remaining_bytes,
 	}
 #endif
 	skcipher_request_set_crypt(req, src_sg, dst_sg,
-				   (*key_rec).enc_key_size, iv);
+				    (*key_rec).enc_key_size, NULL);
 	rc = crypto_skcipher_encrypt(req);
 	mutex_unlock(tfm_mutex);
 	skcipher_request_free(req);


### PR DESCRIPTION
fix warning on fs/ecryptfs/keystore.c